### PR TITLE
Return http status code before deployTasks completes

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ getConfig(function (config) {
 
                 console.log('Valid payload! Running commands');
 
-                deployTasks.run(function () {
-                    res.status(200).send();
-                });
+                res.status(200).send();
+
+                deployTasks.run();
 
             } else {
                 // if other branches were updated, send 200 only to make github happy...

--- a/lib/deployTasks.js
+++ b/lib/deployTasks.js
@@ -34,7 +34,7 @@ var async = require('async'),
         }
     }
 
-    deployTasks.run = function (cb) {
+    deployTasks.run = function () {
         if (!initConfigCalled) {
             throw new Error('You should call initConfig first');
         }
@@ -45,8 +45,7 @@ var async = require('async'),
             deployTasks.commandFactory(stopCmd),
             deployTasks.commandFactory(updateCmd),
             deployTasks.commandFactory(postUpdateCmd),
-            deployTasks.commandFactory(startCmd),
-            cb
+            deployTasks.commandFactory(startCmd)
         ]);
     };
 })();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-webhooks-listener",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A module to listen to github hooks and to update and deploy project when push event occurs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I discovered that when deployTasks took a long time, Webhook timed out and GitHub handled as an error.
So, I changed the timing to return the http status code before running deployTasks.
![image](https://user-images.githubusercontent.com/21266306/34273020-fe1286a4-e6d5-11e7-87df-bc672b2e8a08.png)
